### PR TITLE
Autosort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ target/*
 .settings/*
 .project
 .classpath
+/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,16 @@
 			<id>simplesorter</id>
 			<url>https://github.com/KingCreator11/SimpleSorter</url>
 		</repository>
+		<repository>
+			<id>spigot-repo</id>
+			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+    	</repository>
 	</repositories>
 	<dependencies>
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.16.5-R0.1-SNAPSHOT</version>
+			<version>1.18.2-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/kingcreator11/simplesorter/Commands/AutoSorter.java
+++ b/src/main/java/com/kingcreator11/simplesorter/Commands/AutoSorter.java
@@ -52,14 +52,25 @@ public class AutoSorter extends SubCommand {
 		 */
 		DBContainer input;
 
+		/*
+			we need these if the player deletes the sorter we check to make sure
+			it still exists.
+		*/
+		String sorter;
+		String playerUUID;
+		SimpleSorter plugin;
+
 		/**
 		 * Creates a new sorting process runner
 		 * @param plugin
 		 * @param input
 		 */
-		public SortingProcessRunner(SimpleSorter plugin, DBContainer input, Inventory inputInv) {
+		public SortingProcessRunner(SimpleSorter plugin, DBContainer input, Inventory inputInv, String sorter, String playerUUID) {
 			process = new SortingProcess(plugin, inputInv, input.sorterId);
 			this.input = input;
+			this.sorter = sorter;
+			this.playerUUID = playerUUID;
+			this.plugin = plugin;
 		}
 
 		/**
@@ -69,7 +80,7 @@ public class AutoSorter extends SubCommand {
 		public void run() {
 			// when we turn off autosort we remove the key from onGoingSorters,
 			// so check for the key and if not there close the process.
-			if (onGoingSorters.containsKey(this.input)) 
+			if (onGoingSorters.containsKey(this.input) && this.plugin.sorterManager.getSorter(this.playerUUID, this.sorter) != null) 
 				process.update();
 			else {
 				onGoingSorters.remove(input);
@@ -186,7 +197,7 @@ public class AutoSorter extends SubCommand {
 		player.sendMessage("Auto sorting process will begin in 5 seconds and move one stack every " + args[1] + " seconds.");
 
 		// Create sorting process runner and run it
-		SortingProcessRunner runner = new SortingProcessRunner(this.plugin, input, ch.getInventory());
+		SortingProcessRunner runner = new SortingProcessRunner(this.plugin, input, ch.getInventory(), args[0], playerUUID);
 		this.onGoingSorters.put(input, runner);
 
 		// Ideally 5 seconds after but can be delayed by lag

--- a/src/main/java/com/kingcreator11/simplesorter/Commands/AutoSorter.java
+++ b/src/main/java/com/kingcreator11/simplesorter/Commands/AutoSorter.java
@@ -1,0 +1,198 @@
+package com.kingcreator11.simplesorter.Commands;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+import com.kingcreator11.simplesorter.SimpleSorter;
+import com.kingcreator11.simplesorter.SimpleSorterBase;
+import com.kingcreator11.simplesorter.Database.DBContainer;
+import com.kingcreator11.simplesorter.SortingProcess.SortingProcess;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.Barrel;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Chest;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.inventory.DoubleChestInventory;
+import org.bukkit.inventory.Inventory;
+
+public class AutoSorter extends SubCommand {
+    
+	/**
+	 * Creates a new AutoSorter command instance
+	 * @param plugin
+	 */
+	public AutoSorter(SimpleSorter plugin) {
+		super(plugin, new String[] {"simplesorter.usage"}, SubCommandType.argString);
+	}
+
+	/*
+	ripped from listenhandler
+	*/
+	private Map<DBContainer, SortingProcessRunner> onGoingSorters = new HashMap<>();
+	private class SortingProcessRunner extends BukkitRunnable {
+
+		/**
+		 * The process used for sorting
+		 */
+		private SortingProcess process;
+
+		/**
+		 * The input container this process is mapped to
+		 */
+		DBContainer input;
+
+		/**
+		 * Creates a new sorting process runner
+		 * @param plugin
+		 * @param input
+		 */
+		public SortingProcessRunner(SimpleSorter plugin, DBContainer input, Inventory inputInv) {
+			process = new SortingProcess(plugin, inputInv, input.sorterId);
+			this.input = input;
+		}
+
+		/**
+		 * Runs and updates the sorting process
+		 */
+		@Override
+		public void run() {
+			// when we turn off autosort we remove the key from onGoingSorters,
+			// so check for the key and if not there close the process.
+			if (this.onGoingSorters.containsKey(this.input)) 
+				process.update();
+			else {
+				onGoingSorters.remove(input);
+				this.cancel();
+			}
+			/*
+			Since we're autosorting if the process is complete, we do nothing!
+			if (process.completed()) {
+				// Process completed! remove ourselves from the map
+				onGoingSorters.remove(input);
+				this.cancel();
+			}
+			*/
+		}
+	}
+
+
+
+	/**
+	 * Executes the sub command
+	 * @param sender The sender of the command
+	 * @param args The arguments of the command
+	 */
+	@Override
+	protected void executeCommand(CommandSender sender, String[] args) {
+		
+		if (!(sender instanceof Player)) {
+			sender.sendMessage("§cOnly players may use this command");
+			return;
+		}
+
+		Player player = (Player) sender;
+		String playerUUID = player.getUniqueId().toString();
+		RayTraceResult result = player.rayTraceBlocks(10);
+		boolean isDoubleChest = false;
+
+		if (result == null) {
+			sender.sendMessage("§cPlease point at a container to sort");
+			return;
+		}
+
+		Block block = result.getHitBlock();
+
+
+		/* these ifs just make sure the player ran the command properly */
+		if (block == null || !this.blockIsSorterContainer(block)) {
+			sender.sendMessage("§cPlease point at a container to sort");
+			return;
+		}
+		if (args.length < 2) {
+			sender.sendMessage("§cCommand usage /ss autosort <name> <seconds>");
+			return;
+		}
+		if (args[0].isEmpty() || args[1].isEmpty()) {
+			sender.sendMessage("§cCommand usage /ss autosort <name> <seconds>");
+			return;
+		}
+		if (!args[1].matches("^[0-9]+$")) {
+			sender.sendMessage("§cSeconds must be a valid number.");
+			return;
+		}
+		if (block.getBlockInventory() instanceof DoubleChestInventory) 
+			isDoubleChest = true;
+
+		/* 
+			ripped from listener, we find the container we're looking for.
+		*/
+		// Loop through containers and check if this is one of them
+		List<DBContainer> containers = this.plugin.inputManager.inputLocations.get(playerUUID);
+		DBContainer input = null;
+
+		// Not a double chest - normal looping through is fine
+		if (!isDoubleChest) {
+			for (DBContainer container : containers){
+				if (container.location.equals(block.getLocation())) {
+					input = container;
+					break;
+				}
+			}
+		}
+		// Double chests need checking for both sides
+		else {
+			DoubleChest doubleChest = (DoubleChest) block.getBlockInventory().getHolder();
+			Chest left = (Chest) doubleChest.getLeftSide();
+			Chest right = (Chest) doubleChest.getRightSide();
+			for (DBContainer container : containers){
+				if (container.location.equals(left.getLocation()) || container.location.equals(right.getLocation())) {
+					input = container;
+					break;
+				}
+			}
+		}
+
+
+
+		// The container in question isn't an input container
+		if (input == null) return;
+
+
+		// Check if there's already a sorting process occurring for this chest
+		// if so we turn off the autosorting.
+		if (this.onGoingSorters.containsKey(input)) {
+			player.sendMessage("turning off autosort for this input chest");
+			onGoingSorters.remove(input);
+			return;
+		}
+
+
+		// All checks done - this chest is an input chest.
+		player.sendMessage("Auto sorting process will begin in 5 seconds and move one stack every " + args[1] + " seconds.");
+
+		// Create sorting process runner and run it
+		SortingProcessRunner runner = new SortingProcessRunner(this.plugin, input, block.getBlockInventory());
+		this.onGoingSorters.put(input, runner);
+
+		// Ideally 5 seconds after but can be delayed by lag
+		// our interval is also the desired interval by the user in seconds.
+		int interval = Integer.parseInt(args[1])*20;
+		runner.runTaskTimer(this.plugin, 5*20, interval);
+	}
+
+	// player leaves we turn off all auto sorting by removing all the keys from onGoingSorters
+	// which will kill all the processes.
+	public void stop(String playerUUID) {
+		List<DBContainer> containers = this.plugin.inputManager.inputLocations.get(playerUUID);
+		for (DBContainer c : containers) {
+			if (this.onGoingSorters.containsKey(c))
+				this.onGoingSorters.remove(c);
+		}
+	}
+}

--- a/src/main/java/com/kingcreator11/simplesorter/Commands/HelpCommand.java
+++ b/src/main/java/com/kingcreator11/simplesorter/Commands/HelpCommand.java
@@ -85,7 +85,8 @@ public class HelpCommand extends SubCommand {
 		new CommandInfo("setshulkerinput §9<name>", "Converts a sorter to a shulker based sorter and sets the empty shulker input chest", "simplesorter.shulkers"),
 		new CommandInfo("removeshulkerinput", "Converts a sorter back to a normal item sorter and removes the shulker input chest"),
 		new CommandInfo("sort §9<name>", "Creates a sorter for the held item"),
-		new CommandInfo("removesorter", "Removes a sorter chest")
+		new CommandInfo("removesorter", "Removes a sorter chest"),
+		new CommandInfo("autosort <name> <interval>", "turns autosorting on/off for an input chest and runs every <interval> seconds")
 	};
 
 	/**

--- a/src/main/java/com/kingcreator11/simplesorter/Listeners/ListenerHandler.java
+++ b/src/main/java/com/kingcreator11/simplesorter/Listeners/ListenerHandler.java
@@ -239,5 +239,6 @@ public class ListenerHandler extends SimpleSorterBase implements Listener {
 	@EventHandler
 	public void onPlayerQuitEvent(PlayerQuitEvent event) {
 		this.plugin.inputManager.unloadInputs(event.getPlayer().getUniqueId().toString());
+		this.plugin.autoManager.stop(event.getPlayer().getUniqueId().toString());
 	}
 }

--- a/src/main/java/com/kingcreator11/simplesorter/Listeners/ListenerHandler.java
+++ b/src/main/java/com/kingcreator11/simplesorter/Listeners/ListenerHandler.java
@@ -238,7 +238,7 @@ public class ListenerHandler extends SimpleSorterBase implements Listener {
 	 */
 	@EventHandler
 	public void onPlayerQuitEvent(PlayerQuitEvent event) {
-		this.plugin.inputManager.unloadInputs(event.getPlayer().getUniqueId().toString());
 		this.plugin.autoManager.stop(event.getPlayer().getUniqueId().toString());
+		this.plugin.inputManager.unloadInputs(event.getPlayer().getUniqueId().toString());
 	}
 }

--- a/src/main/java/com/kingcreator11/simplesorter/SimpleSorter.java
+++ b/src/main/java/com/kingcreator11/simplesorter/SimpleSorter.java
@@ -35,7 +35,7 @@ public class SimpleSorter extends JavaPlugin {
 	/**
 	 * The main events handler
 	 */
-	public ListenerHandler eventsHandler = new ListenerHandler(this);
+	private ListenerHandler eventsHandler = new ListenerHandler(this);
 
 	/**
 	 * The main database manager

--- a/src/main/java/com/kingcreator11/simplesorter/SimpleSorter.java
+++ b/src/main/java/com/kingcreator11/simplesorter/SimpleSorter.java
@@ -100,7 +100,7 @@ public class SimpleSorter extends JavaPlugin {
 		this.commandHandler.addSubCommand("removeshulkerinput", new RemoveShulkerInputCommand(this));
 		this.commandHandler.addSubCommand("sort", new SortCommand(this));
 		this.commandHandler.addSubCommand("removesorter", new RemoveSorterCommand(this));
-		this.commandHandler.addSubCommand("autosort", new AutoSorter(this));
+		this.commandHandler.addSubCommand("autosort", autoManager);
 
 		// Events
 		getServer().getPluginManager().registerEvents(eventsHandler, this);

--- a/src/main/java/com/kingcreator11/simplesorter/SimpleSorter.java
+++ b/src/main/java/com/kingcreator11/simplesorter/SimpleSorter.java
@@ -35,7 +35,7 @@ public class SimpleSorter extends JavaPlugin {
 	/**
 	 * The main events handler
 	 */
-	private ListenerHandler eventsHandler = new ListenerHandler(this);
+	public ListenerHandler eventsHandler = new ListenerHandler(this);
 
 	/**
 	 * The main database manager
@@ -67,6 +67,13 @@ public class SimpleSorter extends JavaPlugin {
 	 */
 	public SorterManager sorterManager = new SorterManager(this);
 
+
+	/**
+	 * Auto sorting functionality.
+	 */
+	public AutoSorter autoManager = new AutoSorter(this);
+	
+
 	/**
 	 * Called when the plugin is enabled - startup process
 	 */
@@ -93,6 +100,7 @@ public class SimpleSorter extends JavaPlugin {
 		this.commandHandler.addSubCommand("removeshulkerinput", new RemoveShulkerInputCommand(this));
 		this.commandHandler.addSubCommand("sort", new SortCommand(this));
 		this.commandHandler.addSubCommand("removesorter", new RemoveSorterCommand(this));
+		this.commandHandler.addSubCommand("autosort", new AutoSorter(this));
 
 		// Events
 		getServer().getPluginManager().registerEvents(eventsHandler, this);

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module SimpleSorter {
+	exports com.kingcreator11.simplesorter.Listeners;
+	exports com.kingcreator11.simplesorter;
+	exports com.kingcreator11.simplesorter.Commands;
+	exports com.kingcreator11.simplesorter.SortingProcess;
+	exports com.kingcreator11.simplesorter.Database;
+
+	requires java.sql;
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,9 +1,0 @@
-module SimpleSorter {
-	exports com.kingcreator11.simplesorter.Listeners;
-	exports com.kingcreator11.simplesorter;
-	exports com.kingcreator11.simplesorter.Commands;
-	exports com.kingcreator11.simplesorter.SortingProcess;
-	exports com.kingcreator11.simplesorter.Database;
-
-	requires java.sql;
-}


### PR DESCRIPTION
Hello,

I recently found your plugin and thought it was good but I needed something for my farms to automatically sort chests after hoppers place near constant items in them.

This code creates a new command for your plugin, and updates it to 1.18.2:

/ss autosort sorter name interval, where sorter name is the name of the sorter and the interval is the amount of seconds autosort waits to move a stack from the chest.

It works in near identical methods to how the listen event for inventory works, only I don't close the process once it's done and just let it keep running. The player also points to the inputchest they want to run the autosort on.

using autosort again on the same input container will stop the autosorting, and the player leaving the server will close all of the autosorts happening. Also, if the sorter is deleted associated autosorting input chests will stop. 

I am not sure if you're still developing this plugin anymore, but some others may find this useful.

Thank you,
mj